### PR TITLE
Fix windows compatibility of memwatch.cc

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,6 @@
+Unreleased
+	* Fix windows compatibility of memwatch.cc
+
 v2.0.0
 	* BREAKING: Drop support for Node <= 9.
 	* Add support for Node >= 10.

--- a/src/memwatch.cc
+++ b/src/memwatch.cc
@@ -16,7 +16,6 @@
 
 #include <math.h> // for pow
 #include <time.h> // for time
-#include <sys/time.h>
 
 using namespace v8;
 using namespace node;
@@ -176,10 +175,7 @@ NAN_GC_CALLBACK(memwatch::after_gc) {
 
         Nan::GetHeapStatistics(&hs);
 
-        timeval tv;
-        gettimeofday(&tv, NULL);
-
-        baton->gc_ts = (tv.tv_sec * 1000000) + tv.tv_usec;
+        baton->gc_ts = uv_hrtime() / 1000;
 
         baton->total_heap_size = hs.total_heap_size();
         baton->total_heap_size_executable = hs.total_heap_size_executable();

--- a/tests.js
+++ b/tests.js
@@ -2,6 +2,10 @@ const
 should = require('should'),
 memwatch = require('./');
 
+function hrtimeInMicroseconds() {
+  return process.hrtime.bigint() / 1000n;
+}
+
 describe('the library', function() {
   it('should export a couple functions', function(done) {
     should.exist(memwatch.gc);
@@ -14,10 +18,23 @@ describe('the library', function() {
 });
 describe('calling .gc()', function() {
   it('should cause a stats() event to be emitted', function(done) {
+    let timeBeforeGc;
+
     memwatch.once('stats', function(s) {
+      const timeAfterEvent = hrtimeInMicroseconds();
+
       s.should.be.object;
+
+      (typeof timeBeforeGc).should.equal("bigint");
+      timeAfterEvent.should.be.greaterThan(timeBeforeGc);
+
+      s.gc_ts.should.be.a.Number();
+      s.gc_ts.should.be.within(timeBeforeGc, timeAfterEvent);
+
       done();
     });
+
+    timeBeforeGc = hrtimeInMicroseconds();
     memwatch.gc();
   });
 });


### PR DESCRIPTION
Use `uv_hrtime()` instead of `gettimeofday()`.
This allows for removing the `#include <sys/time.h>` which blocks the install on Windows.